### PR TITLE
Add responsive contact section

### DIFF
--- a/src/components/contact/DesktopContact.tsx
+++ b/src/components/contact/DesktopContact.tsx
@@ -1,0 +1,46 @@
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+import { Input } from "@/components/ui/input"
+import { Textarea } from "@/components/ui/textarea"
+import { Button } from "@/components/ui/button"
+import { useContactForm } from "@/hooks/use-contact-form"
+
+const DesktopContact = () => {
+  const { values, handleChange, handleSubmit } = useContactForm()
+
+  return (
+    <Card className="max-w-2xl mx-auto">
+      <CardHeader>
+        <CardTitle>Contact Us</CardTitle>
+      </CardHeader>
+      <CardContent>
+        <form onSubmit={handleSubmit} className="space-y-4">
+          <Input
+            name="name"
+            placeholder="Your Name"
+            value={values.name}
+            onChange={handleChange}
+          />
+          <Input
+            type="email"
+            name="email"
+            placeholder="Email"
+            value={values.email}
+            onChange={handleChange}
+          />
+          <Textarea
+            name="message"
+            placeholder="Message"
+            value={values.message}
+            onChange={handleChange}
+            className="min-h-[120px]"
+          />
+          <Button type="submit" className="ml-auto block">
+            Send Message
+          </Button>
+        </form>
+      </CardContent>
+    </Card>
+  )
+}
+
+export default DesktopContact

--- a/src/components/contact/MobileContact.tsx
+++ b/src/components/contact/MobileContact.tsx
@@ -1,0 +1,38 @@
+import { Input } from "@/components/ui/input"
+import { Textarea } from "@/components/ui/textarea"
+import { Button } from "@/components/ui/button"
+import { useContactForm } from "@/hooks/use-contact-form"
+
+const MobileContact = () => {
+  const { values, handleChange, handleSubmit } = useContactForm()
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-3 p-4">
+      <Input
+        name="name"
+        placeholder="Your Name"
+        value={values.name}
+        onChange={handleChange}
+      />
+      <Input
+        type="email"
+        name="email"
+        placeholder="Email"
+        value={values.email}
+        onChange={handleChange}
+      />
+      <Textarea
+        name="message"
+        placeholder="Message"
+        value={values.message}
+        onChange={handleChange}
+        className="min-h-[100px]"
+      />
+      <Button type="submit" className="w-full">
+        Send Message
+      </Button>
+    </form>
+  )
+}
+
+export default MobileContact

--- a/src/components/contact/Section9Contact.tsx
+++ b/src/components/contact/Section9Contact.tsx
@@ -1,0 +1,17 @@
+import * as React from "react"
+import { useIsMobile } from "@/hooks/use-mobile"
+
+const DesktopContact = React.lazy(() => import("./DesktopContact"))
+const MobileContact = React.lazy(() => import("./MobileContact"))
+
+const Section9Contact = () => {
+  const isMobile = useIsMobile()
+
+  return (
+    <React.Suspense fallback={null}>
+      {isMobile ? <MobileContact /> : <DesktopContact />}
+    </React.Suspense>
+  )
+}
+
+export default Section9Contact

--- a/src/components/dashboard/Dashboard.tsx
+++ b/src/components/dashboard/Dashboard.tsx
@@ -4,6 +4,7 @@ import SkillsRadarChart from './SkillsRadarChart';
 import ActivityTimeline from './ActivityTimeline';
 import AchievementShowcase from './AchievementShowcase';
 import FeedbackSection from './FeedbackSection';
+import Section9Contact from '@/components/contact/Section9Contact';
 import CertificateComponent from './CertificateComponent';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
@@ -166,6 +167,10 @@ const Dashboard = () => {
                 </div>
               </div>
             </div>
+          </div>
+
+          <div className="mt-8">
+            <Section9Contact />
           </div>
         </div>
       </div>

--- a/src/hooks/use-contact-form.ts
+++ b/src/hooks/use-contact-form.ts
@@ -1,0 +1,25 @@
+import * as React from "react"
+import { toast } from "sonner"
+
+export function useContactForm() {
+  const [values, setValues] = React.useState({
+    name: "",
+    email: "",
+    message: "",
+  })
+
+  function handleChange(
+    e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>
+  ) {
+    const { name, value } = e.target
+    setValues((v) => ({ ...v, [name]: value }))
+  }
+
+  function handleSubmit(e: React.FormEvent<HTMLFormElement>) {
+    e.preventDefault()
+    toast("Thanks for reaching out! We will get back to you soon.")
+    setValues({ name: "", email: "", message: "" })
+  }
+
+  return { values, handleChange, handleSubmit }
+}


### PR DESCRIPTION
## Summary
- introduce `useContactForm` hook for shared form logic
- create mobile & desktop contact components
- switch contact view using viewport detection
- render new contact section in the dashboard

## Testing
- `npm run lint` *(fails: several unrelated lint errors)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68831e163b88832f8180788691a06d9a